### PR TITLE
Discordanza di numero

### DIFF
--- a/src/copertura-temporale_elementi_obbligatori.rst
+++ b/src/copertura-temporale_elementi_obbligatori.rst
@@ -1,4 +1,4 @@
-Elemento obbligatori
+Elementi obbligatori
 ====================
 
 Data inizio ``dcatapit:startDate``


### PR DESCRIPTION
Al momento c'è "Elemento obbligatori".  Sarebbe meglio "Elementi obbligatori". Qui in particolare è soltanto uno, quindi anche "Elemento obbligatorio." Ma non "Elemento obbligatori"