### PR TITLE
Altra discordanza di numero

### DIFF
--- a/src/copertura-temporale_elementi_opzionali.rst
+++ b/src/copertura-temporale_elementi_opzionali.rst
@@ -1,4 +1,4 @@
-Elemento opzionali
+Elementi opzionali
 ==================
 
 Data di fine ``dcatapit:endDate``


### PR DESCRIPTION
Al momento c'è "Elemento opzionali".  Sarebbe meglio "Elementi opzionali". Qui in particolare è soltanto uno, quindi anche "Elemento opzionale" Ma non "Elemento opzionali"